### PR TITLE
Removed the "# Event Name" on the OBS archived event pages and changed the descriptions

### DIFF
--- a/Broadcasters/OBS/Archive/Events/BroadcastCustomMessage.md
+++ b/Broadcasters/OBS/Archive/Events/BroadcastCustomMessage.md
@@ -1,6 +1,6 @@
 ---
 title: BroadcastCustomMessage
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-19T17:55:29.457Z
 tags: 

--- a/Broadcasters/OBS/Archive/Events/Exiting.md
+++ b/Broadcasters/OBS/Archive/Events/Exiting.md
@@ -1,14 +1,12 @@
 ---
 title: Exiting
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:07:36.940Z
 tags: 
 editor: markdown
 dateCreated: 2022-07-15T15:36:41.197Z
 ---
-
-# Exiting
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Heartbeat.md
+++ b/Broadcasters/OBS/Archive/Events/Heartbeat.md
@@ -1,14 +1,12 @@
 ---
 title: Heartbeat
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-20T22:00:58.261Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T20:47:31.411Z
 ---
-
-# Heartbeat
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Media.md
+++ b/Broadcasters/OBS/Archive/Events/Media.md
@@ -1,14 +1,12 @@
 ---
 title: Media
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-09-01T00:53:42.171Z
 tags: 
 editor: markdown
 dateCreated: 2022-07-01T18:38:39.880Z
 ---
-
-# Media
 Added in obs-websocket v4.9.0{.subtitle}
 
 **Note**: These events are only emitted when something actively controls the media/VLC source. In other words, the source will never emit this on its own naturally.{.subtitle}

--- a/Broadcasters/OBS/Archive/Events/Media/MediaEnded.md
+++ b/Broadcasters/OBS/Archive/Events/Media/MediaEnded.md
@@ -1,6 +1,6 @@
 ---
 title: MediaEnded
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:07:44.689Z
 tags: 

--- a/Broadcasters/OBS/Archive/Events/Media/MediaNext.md
+++ b/Broadcasters/OBS/Archive/Events/Media/MediaNext.md
@@ -1,6 +1,6 @@
 ---
 title: MediaNext
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:07:49.605Z
 tags: 

--- a/Broadcasters/OBS/Archive/Events/Media/MediaPaused.md
+++ b/Broadcasters/OBS/Archive/Events/Media/MediaPaused.md
@@ -1,14 +1,12 @@
 ---
 title: MediaPaused
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:07:53.835Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T16:24:31.448Z
 ---
-
-# MediaPaused
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Media/MediaPlaying.md
+++ b/Broadcasters/OBS/Archive/Events/Media/MediaPlaying.md
@@ -1,14 +1,12 @@
 ---
 title: MediaPlaying
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:07:57.238Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T16:20:32.304Z
 ---
-
-# MediaPlaying
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Media/MediaPrevious.md
+++ b/Broadcasters/OBS/Archive/Events/Media/MediaPrevious.md
@@ -1,14 +1,12 @@
 ---
 title: MediaPrevious
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:08:01.687Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T16:32:27.748Z
 ---
-
-# MediaPrevious
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Media/MediaRestarted.md
+++ b/Broadcasters/OBS/Archive/Events/Media/MediaRestarted.md
@@ -1,14 +1,12 @@
 ---
 title: MediaRestarted
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:08:05.417Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T16:26:02.254Z
 ---
-
-# MediaRestarted
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Media/MediaStarted.md
+++ b/Broadcasters/OBS/Archive/Events/Media/MediaStarted.md
@@ -1,14 +1,12 @@
 ---
 title: MediaStarted
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:08:08.950Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T16:33:33.821Z
 ---
-
-# MediaStarted
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Media/MediaStopped.md
+++ b/Broadcasters/OBS/Archive/Events/Media/MediaStopped.md
@@ -1,14 +1,12 @@
 ---
 title: MediaStopped
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:08:12.395Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T16:27:45.471Z
 ---
-
-# MediaStopped
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Profiles/ProfileChanged.md
+++ b/Broadcasters/OBS/Archive/Events/Profiles/ProfileChanged.md
@@ -1,14 +1,12 @@
 ---
 title: ProfileChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:08:16.779Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T09:32:13.600Z
 ---
-
-# ProfileChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Profiles/ProfileListChanged.md
+++ b/Broadcasters/OBS/Archive/Events/Profiles/ProfileListChanged.md
@@ -1,14 +1,12 @@
 ---
 title: ProfileListChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:08:20.714Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T09:34:31.158Z
 ---
-
-# ProfileListChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Recording.md
+++ b/Broadcasters/OBS/Archive/Events/Recording.md
@@ -1,14 +1,12 @@
 ---
 title: Recording
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-17T22:25:13.474Z
 tags: 
 editor: markdown
 dateCreated: 2022-07-01T18:38:46.909Z
 ---
-
-# Recording
 Events related to current recording status{.subtitle}
 * [**RecordingStarting *A request to start recording has been issued***](/en/Broadcasters/OBS/Archive/Events/Recording/RecordingStarting)
 * [**RecordingStarted *Recording started successfully***](/en/Broadcasters/OBS/Archive/Events/Recording/RecordingStarted)

--- a/Broadcasters/OBS/Archive/Events/Recording/RecordingPaused.md
+++ b/Broadcasters/OBS/Archive/Events/Recording/RecordingPaused.md
@@ -1,14 +1,12 @@
 ---
 title: RecordingPaused
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:08:24.428Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T18:11:35.645Z
 ---
-
-# RecordingPaused
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Recording/RecordingResumed.md
+++ b/Broadcasters/OBS/Archive/Events/Recording/RecordingResumed.md
@@ -1,14 +1,12 @@
 ---
 title: RecordingResumed
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:08:27.885Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T18:16:59.180Z
 ---
-
-# RecordingResumed
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Recording/RecordingStarted.md
+++ b/Broadcasters/OBS/Archive/Events/Recording/RecordingStarted.md
@@ -1,14 +1,12 @@
 ---
 title: RecordingStarted
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:08:32.416Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T01:43:16.510Z
 ---
-
-# RecordingStarted
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Recording/RecordingStarting.md
+++ b/Broadcasters/OBS/Archive/Events/Recording/RecordingStarting.md
@@ -1,14 +1,12 @@
 ---
 title: RecordingStarting
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-09-01T07:28:20.891Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T17:28:11.096Z
 ---
-
-# RecordingStarting
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Recording/RecordingStopped.md
+++ b/Broadcasters/OBS/Archive/Events/Recording/RecordingStopped.md
@@ -1,14 +1,12 @@
 ---
 title: RecordingStopped
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:08:39.700Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T01:44:48.387Z
 ---
-
-# RecordingStopped
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Recording/RecordingStopping.md
+++ b/Broadcasters/OBS/Archive/Events/Recording/RecordingStopping.md
@@ -1,14 +1,12 @@
 ---
 title: RecordingStopping
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:08:43.195Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T18:03:51.600Z
 ---
-
-# RecordingStopping
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Replay-Buffer.md
+++ b/Broadcasters/OBS/Archive/Events/Replay-Buffer.md
@@ -1,14 +1,12 @@
 ---
 title: Replay Buffer
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-17T22:25:39.989Z
 tags: 
 editor: markdown
 dateCreated: 2022-07-01T18:38:53.015Z
----
-
-# Replay Buffer
+--- Buffer
 Added in obs-websocket v4.2.0{.subtitle}
 * [**ReplayStarting *A request to start the replay buffer has been issued***](/en/Broadcasters/OBS/Archive/Events/Replay-Buffer/ReplayStarting)
 * [**ReplayStarted *Replay Buffer started successfully***](/en/Broadcasters/OBS/Archive/Events/Replay-Buffer/ReplayStarted)

--- a/Broadcasters/OBS/Archive/Events/Replay-Buffer/ReplayStarted.md
+++ b/Broadcasters/OBS/Archive/Events/Replay-Buffer/ReplayStarted.md
@@ -1,14 +1,12 @@
 ---
 title: ReplayStarted
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:08:48.764Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T20:04:59.521Z
 ---
-
-# ReplayStarted
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Replay-Buffer/ReplayStarting.md
+++ b/Broadcasters/OBS/Archive/Events/Replay-Buffer/ReplayStarting.md
@@ -1,14 +1,12 @@
 ---
 title: ReplayStarting
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:08:52.332Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T20:02:19.267Z
 ---
-
-# ReplayStarting
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Replay-Buffer/ReplayStopped.md
+++ b/Broadcasters/OBS/Archive/Events/Replay-Buffer/ReplayStopped.md
@@ -1,14 +1,12 @@
 ---
 title: ReplayStopped
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:08:56.142Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T20:12:14.645Z
 ---
-
-# ReplayStopped
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Replay-Buffer/ReplayStopping.md
+++ b/Broadcasters/OBS/Archive/Events/Replay-Buffer/ReplayStopping.md
@@ -1,14 +1,12 @@
 ---
 title: ReplayStopping
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:09:00.139Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T20:10:25.740Z
 ---
-
-# ReplayStopping
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Scene-Items.md
+++ b/Broadcasters/OBS/Archive/Events/Scene-Items.md
@@ -1,6 +1,6 @@
 ---
 title: Scene Items
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-17T22:25:57.912Z
 tags: 

--- a/Broadcasters/OBS/Archive/Events/Scene-Items/SceneItemAdded.md
+++ b/Broadcasters/OBS/Archive/Events/Scene-Items/SceneItemAdded.md
@@ -1,14 +1,12 @@
 ---
 title: SceneItemAdded
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:09:05.168Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T17:41:08.865Z
 ---
-
-# SceneItemAdded
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Scene-Items/SceneItemDeselected.md
+++ b/Broadcasters/OBS/Archive/Events/Scene-Items/SceneItemDeselected.md
@@ -1,14 +1,12 @@
 ---
 title: SceneItemDeselected
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:09:09.272Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T18:19:56.970Z
 ---
-
-# SceneItemDeselected
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Scene-Items/SceneItemLockChanged.md
+++ b/Broadcasters/OBS/Archive/Events/Scene-Items/SceneItemLockChanged.md
@@ -1,14 +1,12 @@
 ---
 title: SceneItemLockChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:09:13.029Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T17:48:06.836Z
 ---
-
-# SceneItemLockChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Scene-Items/SceneItemRemoved.md
+++ b/Broadcasters/OBS/Archive/Events/Scene-Items/SceneItemRemoved.md
@@ -1,14 +1,12 @@
 ---
 title: SceneItemRemoved
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:09:17.905Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T17:42:58.371Z
 ---
-
-# SceneItemRemoved
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Scene-Items/SceneItemSelected.md
+++ b/Broadcasters/OBS/Archive/Events/Scene-Items/SceneItemSelected.md
@@ -1,14 +1,12 @@
 ---
 title: SceneItemSelected
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:09:21.645Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T18:18:30.715Z
 ---
-
-# SceneItemSelected
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Scene-Items/SceneItemTransformChanged.md
+++ b/Broadcasters/OBS/Archive/Events/Scene-Items/SceneItemTransformChanged.md
@@ -1,14 +1,12 @@
 ---
 title: SceneItemTransformChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:09:25.680Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T18:13:10.114Z
 ---
-
-# SceneItemTransformChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Scene-Items/SceneItemVisibilityChanged.md
+++ b/Broadcasters/OBS/Archive/Events/Scene-Items/SceneItemVisibilityChanged.md
@@ -1,14 +1,12 @@
 ---
 title: SceneItemVisibilityChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:09:29.314Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T17:45:20.166Z
 ---
-
-# SceneItemVisibilityChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Scene-Items/SourceOrderChanged.md
+++ b/Broadcasters/OBS/Archive/Events/Scene-Items/SourceOrderChanged.md
@@ -1,14 +1,12 @@
 ---
 title: SourceOrderChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:09:36.696Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T16:47:50.777Z
 ---
-
-# SourceOrderChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Scenes.md
+++ b/Broadcasters/OBS/Archive/Events/Scenes.md
@@ -1,14 +1,12 @@
 ---
 title: Scenes
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-17T22:26:31.402Z
 tags: 
 editor: markdown
 dateCreated: 2022-07-01T18:39:05.038Z
 ---
-
-# Scene
 Scene change & collection events{.subtitle}
 * [**SwitchScenes *Event triggered **before** a scene change***](/en/Broadcasters/OBS/Archive/Events/Scenes/SwitchScenes)
 * [**ScenesChanged *Event triggered **after** a scene change***](/en/Broadcasters/OBS/Archive/Events/Scenes/ScenesChanged)

--- a/Broadcasters/OBS/Archive/Events/Scenes/SceneCollectionChanged.md
+++ b/Broadcasters/OBS/Archive/Events/Scenes/SceneCollectionChanged.md
@@ -1,14 +1,12 @@
 ---
 title: SceneCollectionChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:09:40.564Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T01:58:18.909Z
 ---
-
-# SceneCollectionChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Scenes/SceneCollectionListChanged.md
+++ b/Broadcasters/OBS/Archive/Events/Scenes/SceneCollectionListChanged.md
@@ -1,14 +1,12 @@
 ---
 title: SceneCollectionListChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:09:44.323Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T02:04:40.915Z
 ---
-
-# SceneCollectionChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Scenes/ScenesChanged.md
+++ b/Broadcasters/OBS/Archive/Events/Scenes/ScenesChanged.md
@@ -1,14 +1,12 @@
 ---
 title: ScenesChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:09:48.746Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T01:53:30.436Z
 ---
-
-# ScenesChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Scenes/SwitchScenes.md
+++ b/Broadcasters/OBS/Archive/Events/Scenes/SwitchScenes.md
@@ -1,14 +1,12 @@
 ---
 title: SwitchScenes
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-08-05T12:29:55.253Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T01:09:06.949Z
 ---
-
-# SwitchScenes
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/SourceAudioActivated.md
+++ b/Broadcasters/OBS/Archive/Events/SourceAudioActivated.md
@@ -1,14 +1,12 @@
 ---
 title: SourceAudioActivated
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:09:56.327Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T15:12:08.670Z
 ---
-
-# SourceAudioActivated
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/SourceAudioDeactivated.md
+++ b/Broadcasters/OBS/Archive/Events/SourceAudioDeactivated.md
@@ -1,14 +1,12 @@
 ---
 title: SourceAudioDeactivated
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:10:00.965Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T15:09:24.345Z
 ---
-
-# SourceAudioDeactivated
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/SourceAudioMixersChanged.md
+++ b/Broadcasters/OBS/Archive/Events/SourceAudioMixersChanged.md
@@ -1,14 +1,12 @@
 ---
 title: SourceAudioMixersChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:10:05.904Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T15:35:36.718Z
 ---
-
-# SourceAudioMixersChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/SourceAudioSyncOffsetChanged.md
+++ b/Broadcasters/OBS/Archive/Events/SourceAudioSyncOffsetChanged.md
@@ -1,14 +1,12 @@
 ---
 title: SourceAudioSyncOffsetChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:10:09.661Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T15:18:29.858Z
 ---
-
-# SourceAudioSyncOffsetChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/SourceMuteStateChanged.md
+++ b/Broadcasters/OBS/Archive/Events/SourceMuteStateChanged.md
@@ -1,14 +1,12 @@
 ---
 title: SourceMuteStateChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:10:37.592Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T14:17:21.696Z
 ---
-
-# SourceMuteStateChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/SourceVolumeChanged.md
+++ b/Broadcasters/OBS/Archive/Events/SourceVolumeChanged.md
@@ -1,14 +1,12 @@
 ---
 title: SourceVolumeChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:10:45.164Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T14:08:48.776Z
 ---
-
-# SourceVolumeChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Sources.md
+++ b/Broadcasters/OBS/Archive/Events/Sources.md
@@ -1,14 +1,12 @@
 ---
 title: Sources
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-17T22:26:49.170Z
 tags: 
 editor: markdown
 dateCreated: 2022-07-01T18:39:10.304Z
 ---
-
-# Source
 Events related to source & filter changes{.subtitle}
 * [**SourceCreated *A source has been created***](/en/Broadcasters/OBS/Archive/Events/Sources/SourceCreated)
 * [**SourceDestroyed *A source has been removed***](/en/Broadcasters/OBS/Archive/Events/Sources/SourceDestroyed)

--- a/Broadcasters/OBS/Archive/Events/Sources/SourceCreated.md
+++ b/Broadcasters/OBS/Archive/Events/Sources/SourceCreated.md
@@ -1,14 +1,12 @@
 ---
 title: SourceCreated
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:10:13.084Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T13:55:54.310Z
 ---
-
-# SourceCreated
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Sources/SourceDestroyed.md
+++ b/Broadcasters/OBS/Archive/Events/Sources/SourceDestroyed.md
@@ -1,14 +1,12 @@
 ---
 title: SourceDestroyed
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:10:17.753Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T14:01:31.642Z
 ---
-
-# SourceDestroyed
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Sources/SourceFilterAdded.md
+++ b/Broadcasters/OBS/Archive/Events/Sources/SourceFilterAdded.md
@@ -1,14 +1,12 @@
 ---
 title: SourceFilterAdded
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:10:21.300Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T15:53:48.965Z
 ---
-
-# SourceFilterAdded
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Sources/SourceFilterRemoved.md
+++ b/Broadcasters/OBS/Archive/Events/Sources/SourceFilterRemoved.md
@@ -1,14 +1,12 @@
 ---
 title: SourceFilterRemoved
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:10:25.733Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T15:55:46.848Z
 ---
-
-# SourceFilterRemoved
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Sources/SourceFilterVisibilityChanged.md
+++ b/Broadcasters/OBS/Archive/Events/Sources/SourceFilterVisibilityChanged.md
@@ -1,14 +1,12 @@
 ---
 title: SourceFilterVisibilityChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:10:29.395Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T16:00:01.166Z
 ---
-
-# SourceFilterVisibilityChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Sources/SourceFiltersReordered.md
+++ b/Broadcasters/OBS/Archive/Events/Sources/SourceFiltersReordered.md
@@ -1,14 +1,12 @@
 ---
 title: SourceFiltersReordered
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:10:33.948Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T16:07:15.707Z
 ---
-
-# SourceFiltersReordered
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Sources/SourceRenamed.md
+++ b/Broadcasters/OBS/Archive/Events/Sources/SourceRenamed.md
@@ -1,14 +1,12 @@
 ---
 title: SourceRenamed
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:10:41.456Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T15:42:26.234Z
 ---
-
-# SourceRenamed
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Streaming.md
+++ b/Broadcasters/OBS/Archive/Events/Streaming.md
@@ -1,14 +1,12 @@
 ---
 title: Streaming
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-17T22:27:40.446Z
 tags: 
 editor: markdown
 dateCreated: 2022-07-01T18:39:16.364Z
 ---
-
-# Stream
 Events related to current streaming status{.subtitle}
 * [**StreamStarting *A request to start streaming has been issued***](/en/Broadcasters/OBS/Archive/Events/Streaming/StreamStarting)
 * [**StreamStarted *Streaming started successfully***](/en/Broadcasters/OBS/Archive/Events/Streaming/StreamStarted)

--- a/Broadcasters/OBS/Archive/Events/Streaming/StreamStarted.md
+++ b/Broadcasters/OBS/Archive/Events/Streaming/StreamStarted.md
@@ -1,14 +1,12 @@
 ---
 title: StreamStarted
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:10:49.565Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T01:29:42.941Z
 ---
-
-# StreamStarted
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Streaming/StreamStarting.md
+++ b/Broadcasters/OBS/Archive/Events/Streaming/StreamStarting.md
@@ -1,14 +1,12 @@
 ---
 title: StreamStarting
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:10:53.433Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T10:15:12.315Z
 ---
-
-# StreamStarting
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Streaming/StreamStatus.md
+++ b/Broadcasters/OBS/Archive/Events/Streaming/StreamStatus.md
@@ -1,14 +1,12 @@
 ---
 title: StreamStatus
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:10:57.908Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T13:51:20.162Z
 ---
-
-# StreamStatus
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Streaming/StreamStopped.md
+++ b/Broadcasters/OBS/Archive/Events/Streaming/StreamStopped.md
@@ -1,14 +1,12 @@
 ---
 title: StreamStopped
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:11:02.729Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T01:38:33.073Z
 ---
-
-# StreamStopped
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Streaming/StreamStopping.md
+++ b/Broadcasters/OBS/Archive/Events/Streaming/StreamStopping.md
@@ -1,14 +1,12 @@
 ---
 title: StreamStopping
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:11:06.541Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T13:23:13.161Z
 ---
-
-# StreamStopping
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Studio-Mode/PreviewSceneChanged.md
+++ b/Broadcasters/OBS/Archive/Events/Studio-Mode/PreviewSceneChanged.md
@@ -1,14 +1,12 @@
 ---
 title: PreviewSceneChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:11:10.962Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T19:12:25.206Z
 ---
-
-# PreviewSceneChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Studio-Mode/StudioModeSwitched.md
+++ b/Broadcasters/OBS/Archive/Events/Studio-Mode/StudioModeSwitched.md
@@ -1,14 +1,12 @@
 ---
 title: StudioModeSwitched
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:11:15.668Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-28T19:16:06.430Z
 ---
-
-# StudioModeSwitched
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Transitions.md
+++ b/Broadcasters/OBS/Archive/Events/Transitions.md
@@ -1,14 +1,12 @@
 ---
 title: Transitions
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-17T22:28:10.156Z
 tags: 
 editor: markdown
 dateCreated: 2022-07-01T18:39:23.492Z
 ---
-
-# Transition
 Events related to transition changes{.subtitle}
 * [**SwitchTransition *The active transition has been changed***](/en/Broadcasters/OBS/Archive/Events/Transitions/SwitchTransition)
 * [**TransitionListChanged *The list of available transitions has been modified. Transitions have been added, removed, or renamed***](/en/Broadcasters/OBS/Archive/Events/Transitions/TransitionListChanged)

--- a/Broadcasters/OBS/Archive/Events/Transitions/SwitchTransition.md
+++ b/Broadcasters/OBS/Archive/Events/Transitions/SwitchTransition.md
@@ -1,14 +1,12 @@
 ---
 title: SwitchTransition
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T19:42:49.773Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T02:25:48.408Z
 ---
-
-# SwitchTransition
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Transitions/TransitionBegin.md
+++ b/Broadcasters/OBS/Archive/Events/Transitions/TransitionBegin.md
@@ -1,14 +1,12 @@
 ---
 title: TransitionBegin
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:11:24.222Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T02:40:20.421Z
 ---
-
-# TransitionBegin
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Transitions/TransitionDurationChanged.md
+++ b/Broadcasters/OBS/Archive/Events/Transitions/TransitionDurationChanged.md
@@ -1,14 +1,12 @@
 ---
 title: TransitionDurationChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:11:28.226Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T02:34:57.760Z
 ---
-
-# TransitionDurationChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Transitions/TransitionEnd.md
+++ b/Broadcasters/OBS/Archive/Events/Transitions/TransitionEnd.md
@@ -1,14 +1,12 @@
 ---
 title: TransitionEnd
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-09-01T07:30:24.501Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T02:42:12.078Z
 ---
-
-# TransitionEnd
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Transitions/TransitionListChanged.md
+++ b/Broadcasters/OBS/Archive/Events/Transitions/TransitionListChanged.md
@@ -1,14 +1,12 @@
 ---
 title: TransitionListChanged
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:11:36.957Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T02:32:10.168Z
 ---
-
-# TransitionListChanged
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Transitions/TransitionVideoEnd.md
+++ b/Broadcasters/OBS/Archive/Events/Transitions/TransitionVideoEnd.md
@@ -1,14 +1,12 @@
 ---
 title: TransitionVideoEnd
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:11:40.954Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T02:45:18.870Z
 ---
-
-# TransitionVideoEnd
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Virtual-Cam.md
+++ b/Broadcasters/OBS/Archive/Events/Virtual-Cam.md
@@ -1,14 +1,12 @@
 ---
 title: Virtual Cam
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-17T22:28:36.364Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T09:58:00.765Z
----
-
-# Virtual Cam
+--- Cam
 Added in obs-websocket v4.9.1{.subtitle}
 * [**VirtualCamStarted *Virtual cam started successfully***](/en/Broadcasters/OBS/Archive/Events/Virtual-Cam/VirtualCamStarted)
 * [**VirtualCamStopped *Virtual cam stopped successfully***](/en/Broadcasters/OBS/Archive/Events/Virtual-Cam/VirtualCamStopped)

--- a/Broadcasters/OBS/Archive/Events/Virtual-Cam/VirtualCamStarted.md
+++ b/Broadcasters/OBS/Archive/Events/Virtual-Cam/VirtualCamStarted.md
@@ -1,14 +1,12 @@
 ---
 title: VirtualCamStarted
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:11:44.551Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T18:21:56.344Z
 ---
-
-# VirtualCamStarted
 
 ## Variables
 

--- a/Broadcasters/OBS/Archive/Events/Virtual-Cam/VirtualCamStopped.md
+++ b/Broadcasters/OBS/Archive/Events/Virtual-Cam/VirtualCamStopped.md
@@ -1,14 +1,12 @@
 ---
 title: VirtualCamStopped
-description: OBS Studio Events Reference
+description: OBS Studio Events Reference (Archive)
 published: true
 date: 2022-07-18T16:11:49.590Z
 tags: 
 editor: markdown
 dateCreated: 2022-06-27T18:23:44.597Z
 ---
-
-# VirtualCamStopped
 
 ## Variables
 


### PR DESCRIPTION
Before there was e.g. # SceneItemAdded and now it's gone