### PR TITLE
Fix CSharp Links

### DIFF
--- a/Broadcasters/StreamlabsDesktop.md
+++ b/Broadcasters/StreamlabsDesktop.md
@@ -2,7 +2,7 @@
 title: Streamlabs Desktop
 description: Configure Streamlabs Desktop as a broadcaster in Streamer.bot
 published: true
-date: 2022-10-29T21:57:43.828Z
+date: 2023-04-08T14:11:29
 tags: broadcasters, streamlabsdesktop
 editor: markdown
 dateCreated: 2021-08-25T21:32:18.787Z
@@ -13,7 +13,7 @@ dateCreated: 2021-08-25T21:32:18.787Z
 ## Overview
 Control your Streamlabs Desktop instance(s) with Streamer.bot
 
-Adding at least one connection will allow you to control your Streamlabs Desktop either through the various [sub-actions](/Sub-Actions) that have been included, or via the [Execute C# Code](/Sub-Actions/Code/Execute-CSharp-Code) sub-action
+Adding at least one connection will allow you to control your Streamlabs Desktop either through the various [sub-actions](/Sub-Actions) that have been included, or via the [Execute C# Code](/Sub-Actions/Code/CSharp) sub-action
 
 ## Configuration
 `Right-Click` `->` `Add` to define a new connection

--- a/Platforms/Twitch/Polls.md
+++ b/Platforms/Twitch/Polls.md
@@ -2,7 +2,7 @@
 title: Polls
 description: Twitch Events Reference
 published: true
-date: 2023-03-16T12:56:59.987Z
+date: 2023-04-08T14:11:12
 tags: 
 editor: markdown
 dateCreated: 2021-08-25T21:34:34.620Z
@@ -126,7 +126,7 @@ Because how some of this is handled, it is recommended that Execute C# code is u
 
 ## Basic Creation Example
 
-Since the initial usage of creating polls currently requires [Execute C# Code](/Sub-Actions/Code/Execute-CSharp-Code), a simple example is provided below.  I've added a few comments to it which hopefully will help you get it setup for your usage.  If you still have questions, be sure to ask them in the discord!
+Since the initial usage of creating polls currently requires [Execute C# Code](/Sub-Actions/Code/CSharp), a simple example is provided below.  I've added a few comments to it which hopefully will help you get it setup for your usage.  If you still have questions, be sure to ask them in the discord!
 
 ### Code
 

--- a/Platforms/Twitch/Predictions.md
+++ b/Platforms/Twitch/Predictions.md
@@ -2,7 +2,7 @@
 title: Predictions
 description: Twitch Events Reference
 published: true
-date: 2023-03-16T12:57:27.808Z
+date: 2023-04-08T14:11:03
 tags: 
 editor: markdown
 dateCreated: 2021-08-25T21:34:38.706Z
@@ -98,7 +98,7 @@ Because how some of this is handled, it is recommended that Execute C# code is u
 **Note** if there are variables missing that you think maybe of benefit, let us know [here](https://ideas.streamer.bot) and we can likely add them in
 
 ## Basic Creation Example
-To create a prediction outside of the UI, you will need to use [Execute C# Code](/Sub-Actions/Code/Execute-CSharp-Code), a simple example is provided below.  I've added a few comments to it which hopefully will help you get it setup for your usage.  If you still have questions, be sure to ask them in the discord!
+To create a prediction outside of the UI, you will need to use [Execute C# Code](/Sub-Actions/Code/CSharp), a simple example is provided below.  I've added a few comments to it which hopefully will help you get it setup for your usage.  If you still have questions, be sure to ask them in the discord!
 
 ### Code
 

--- a/Servers-Clients/WebSocket-Clients.md
+++ b/Servers-Clients/WebSocket-Clients.md
@@ -2,17 +2,17 @@
 title: WebSocket Clients
 description: Configure Streamer.bot to connect to an external WebSocket server
 published: true
-date: 2023-03-16T13:16:27.376Z
+date: 2023-04-08T14:10:51
 tags: websocket
 editor: markdown
 dateCreated: 2021-08-25T21:37:08.368Z
 ---
 
-> Currently, due to the nature of the Websocket Client, the only real use for these is within the [Execute C# Code](/Sub-Actions/Code/Execute-CSharp-Code) sub-action.
+> Currently, due to the nature of the Websocket Client, the only real use for these is within the [Execute C# Code](/Sub-Actions/Code/CSharp) sub-action.
 {.is-info}
 
 ## Overview
-WebSocket clients allow you to connect to external WebSocket servers and setup corresponding actions using the [Execute C# Code](/Sub-Actions/Code/Execute-CSharp-Code) sub-action to react to events that are emitted by the the respective server.  
+WebSocket clients allow you to connect to external WebSocket servers and setup corresponding actions using the [Execute C# Code](/Sub-Actions/Code/CSharp) sub-action to react to events that are emitted by the the respective server.  
 
 For example, you could connect to the **Data Puller Beat Saber Mod** and perform various actions based on the data receieved.
 


### PR DESCRIPTION
Fixed multiple Hyperlinks that were referring to /Sub-Actions/Code/Execute-CSharp-Code that are now point to where it is now located /Sub-Actions/Code/CSharp