### PR TITLE
Add missing word `software` in Set-Channel-Game.md

### DIFF
--- a/Sub-Actions/Twitch/Set-Channel-Game.md
+++ b/Sub-Actions/Twitch/Set-Channel-Game.md
@@ -29,7 +29,7 @@ Name | Description
 `gameSuccess` | If the Sub-Action succeeded <br> `True`/`False`
 `gameName` | The name of the game
 `gameId` | The id of the game
-`gameBoxArt` | The url of the game boxart, can be used with browser sources in your broadcaster.
+`gameBoxArt` | The url of the game boxart, can be used with browser sources in your broadcaster software.
 {.vars-table}
 
 ---


### PR DESCRIPTION
I just want to look something up and found there to be a word missing. I don't know why line 38 is marked to be a change, because I didn't change anything there.